### PR TITLE
Some UI scaling fixes

### DIFF
--- a/Altoholic/Utils.cs
+++ b/Altoholic/Utils.cs
@@ -46,6 +46,44 @@ namespace Altoholic
             return "DC";
         }
 
+        /// <summary>
+        /// Scales the column width based on the global scale and optional padding.
+        /// </summary>
+        /// <param name="width"> The base width of the column.</param>
+        /// <param name="padding"> The padding to be applied to the column width.</param>"
+        /// <remarks>
+        /// Calculates the scaled width by multiplying the base width with the global scale and optional padding.
+        /// </remarks>
+        public static float GetColumnWidthScaled(float width, float padding = 1.0f)
+        {
+            float globalScale = Dalamud.Interface.Utility.ImGuiHelpers.GlobalScaleSafe;
+            float fontSize = (width * padding) * globalScale;
+            Plugin.Log.Debug($"Global Scale: {globalScale}");
+
+            // Base width + some padding based on font size
+            return Math.Max(width * padding, fontSize * padding);
+        }
+
+        /// <summary>
+        /// Centers text horizontally within the current ImGui column.
+        /// </summary>
+        /// <param name="text">The text to be centered and displayed</param>
+        /// <remarks>
+        /// Calculates the required offset by finding the difference between column width and text width,
+        /// then positions the cursor and renders the text at the calculated position.
+        /// 
+        /// May want to move this to Utils if it's desired in other classes, but so far Checks and Circles
+        /// seem most relevant for this, and it's only really be a small amount.
+        /// </remarks>
+        public static void CentreText(string text)
+        {
+            float columnWidth = ImGui.GetColumnWidth();
+            float iconWidth = ImGui.CalcTextSize(text).X;
+            float offset = (columnWidth - iconWidth) / 2.0f;
+            ImGui.SetCursorPosX(ImGui.GetCursorPosX() + offset);
+            ImGui.TextUnformatted(text);
+        }
+
         public static void ChatMessage(string message)
         {
             Plugin.ChatGui.Print($"[Altoholic] {message}");
@@ -1775,7 +1813,7 @@ namespace Altoholic
                     ImGuiTableColumnFlags.WidthFixed, 55);
                 ImGui.TableSetupColumn($"###DrawItemTooltip#Item_{item.RowId}#NameIcon#Name",
                     ImGuiTableColumnFlags.WidthFixed, 305);
-  
+
                 ImGui.TableNextRow();
                 ImGui.TableSetColumnIndex(0);
                 DrawIcon(globalCache.IconStorage.LoadIcon(item.Icon), new Vector2(40, 40));
@@ -2765,7 +2803,7 @@ namespace Altoholic
             Addon? lumina = da.GetRow((uint)id);
             return lumina != null ? lumina.Value.Text.ExtractText() : string.Empty;
         }
-        
+
         public static Companion? GetMinion(ClientLanguage currentLocale, uint id)
         {
             ExcelSheet<Companion>? dc = Plugin.DataManager.GetExcelSheet<Companion>(currentLocale);
@@ -3378,7 +3416,7 @@ namespace Altoholic
             items.AddRange(str.Split("_").Select(Capitalize));
             return string.Join("_", items);
         }
-        
+
         public static string CapitalizeCurrency(string str)
         {
             if (str is "MGP" or "MGF")
@@ -3887,7 +3925,7 @@ namespace Altoholic
             ClassJobCategory? lumina = djc.GetRow(id.Value);
             return lumina != null ? lumina.Value.Name.ExtractText() : string.Empty;
         }
-        
+
         public static ClassJob? GetClassJobFromId(uint? id, ClientLanguage clientLanguage)
         {
             //Plugin.Log.Debug($"GetItemNameFromId : {id}");
@@ -4233,12 +4271,12 @@ namespace Altoholic
         }
 
         public static long GetLastPlayTimeUpdateDiff(long lastOnline)
-           {
-               long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-               long diff = now - lastOnline;
-               long diffDays = Math.Abs(diff / 86400);
-               return diffDays;
-           }
+        {
+            long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            long diff = now - lastOnline;
+            long diffDays = Math.Abs(diff / 86400);
+            return diffDays;
+        }
 
         public static string GetLastOnlineFormatted(long lastOnline /*, string firstname*/)
         {

--- a/Altoholic/Windows/JobsWindow.cs
+++ b/Altoholic/Windows/JobsWindow.cs
@@ -21,7 +21,7 @@ namespace Altoholic.Windows
         public JobsWindow(
             Plugin plugin,
             string name,
-            GlobalCache globalCache) 
+            GlobalCache globalCache)
             : base(
                 name, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse)
         {
@@ -128,49 +128,52 @@ namespace Altoholic.Windows
                 ImGuiTableFlags.ScrollX | ImGuiTableFlags.ScrollY);
             if (!charactersJobsAll) return;
             // ImGuiCol.TableRowBg = new Vector4(255, 255, 255, 1); ;
-            ImGui.TableSetupColumn("###CharactersJobs#All#Names", ImGuiTableColumnFlags.WidthFixed, 35);
-            ImGui.TableSetupColumn("###CharactersJobs#All#GLA", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#PLD", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#MRD", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#WAR", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#DRK", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#GNB", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#CNJ", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#WHM", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#SCH", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#AST", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#SGE", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#PGL", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#MNK", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#LNC", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#DRG", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#ROG", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#NIN", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#SAM", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#RPR", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#VPR", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#ARC", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#BRD", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#MCH", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#DNC", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#THM", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#BLM", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#ACN", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#SMN", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#RDM", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#PCT", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#BLU", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#CRP", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#BSM", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#ARM", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#GSM", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#LTW", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#WVR", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#ALC", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#CUL", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#MIN", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#BTN", ImGuiTableColumnFlags.WidthFixed, 25);
-            ImGui.TableSetupColumn("###CharactersJobs#All#FSH", ImGuiTableColumnFlags.WidthFixed, 25);
+
+            float headerCellWidth = Utils.GetColumnWidthScaled(35, 1.25f);
+            float jobCellWidth = Utils.GetColumnWidthScaled(25, 1.25f);
+            ImGui.TableSetupColumn("###CharactersJobs#All#Names", ImGuiTableColumnFlags.WidthFixed, headerCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#GLA", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#PLD", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#MRD", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#WAR", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#DRK", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#GNB", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#CNJ", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#WHM", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#SCH", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#AST", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#SGE", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#PGL", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#MNK", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#LNC", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#DRG", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#ROG", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#NIN", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#SAM", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#RPR", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#VPR", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#ARC", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#BRD", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#MCH", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#DNC", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#THM", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#BLM", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#ACN", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#SMN", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#RDM", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#PCT", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#BLU", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#CRP", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#BSM", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#ARM", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#GSM", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#LTW", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#WVR", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#ALC", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#CUL", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#MIN", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#BTN", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+            ImGui.TableSetupColumn("###CharactersJobs#All#FSH", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
 
             ImGui.TableNextRow();
             ImGui.TableSetColumnIndex(0);
@@ -673,7 +676,7 @@ namespace Altoholic.Windows
             ImGui.TableNextRow();
             ImGui.TableSetColumnIndex(1);
             DrawJobLine(selectedCharacter, ClassJob.RDM);
-            
+
             ImGui.TableNextRow();
             ImGui.TableSetColumnIndex(1);
             DrawJobLine(selectedCharacter, ClassJob.PCT);
@@ -1087,41 +1090,42 @@ namespace Altoholic.Windows
             };
             using var charactersJobsJobLine = ImRaii.Table("###CharactersJobs#JobLine", 2);
             if (!charactersJobsJobLine) return;
-                ImGui.TableSetupColumn("###CharactersJobs#Icon", ImGuiTableColumnFlags.WidthFixed, 36);
-                ImGui.TableSetupColumn("###CharactersJobs#LevelNameExp", ImGuiTableColumnFlags.WidthStretch);
+            ImGui.TableSetupColumn("###CharactersJobs#Icon", ImGuiTableColumnFlags.WidthFixed, 36);
+            ImGui.TableSetupColumn("###CharactersJobs#LevelNameExp", ImGuiTableColumnFlags.WidthStretch);
+            ImGui.TableNextRow();
+            ImGui.TableSetColumnIndex(0);
+            Utils.DrawIcon(_globalCache.IconStorage.LoadIcon(Utils.GetJobIconWithCornerSmall((uint)jobId)), new Vector2(36, 36), alpha);
+            ImGui.TableSetColumnIndex(1);
+            using (var charactersJobsJobLevelNameExp = ImRaii.Table("###CharactersJobs#JobLevelNameExp", 2))
+            {
+                if (!charactersJobsJobLevelNameExp) return;
+                float jobCellWidth = Utils.GetColumnWidthScaled(20, 1.25f);
+                ImGui.TableSetupColumn("###CharactersJobs#JobLevelNameExp#Level", ImGuiTableColumnFlags.WidthFixed, jobCellWidth);
+                ImGui.TableSetupColumn("###CharactersJobs#JobLevelNameExp#NameExp", ImGuiTableColumnFlags.WidthStretch);
                 ImGui.TableNextRow();
                 ImGui.TableSetColumnIndex(0);
-                Utils.DrawIcon(_globalCache.IconStorage.LoadIcon(Utils.GetJobIconWithCornerSmall((uint)jobId)), new Vector2(36, 36), alpha);
-                ImGui.TableSetColumnIndex(1);
-                using (var charactersJobsJobLevelNameExp = ImRaii.Table("###CharactersJobs#JobLevelNameExp", 2))
+                if (active)
+                    ImGui.TextUnformatted($"{job.Level}");
+                else
                 {
-                    if (!charactersJobsJobLevelNameExp) return;
-                    ImGui.TableSetupColumn("###CharactersJobs#JobLevelNameExp#Level", ImGuiTableColumnFlags.WidthFixed, 20);
-                    ImGui.TableSetupColumn("###CharactersJobs#JobLevelNameExp#NameExp", ImGuiTableColumnFlags.WidthStretch);
-                    ImGui.TableNextRow();
-                    ImGui.TableSetColumnIndex(0);
-                    if (active)
-                        ImGui.TextUnformatted($"{job.Level}");
-                    else
-                    {
-                        ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f);
-                        ImGui.TextUnformatted($"{job.Level}");
-                        ImGui.PopStyleVar();
-                    }
-                    ImGui.TableSetColumnIndex(1);
-                    if (active)
-                        ImGui.TextUnformatted($"{Utils.Capitalize(_globalCache.JobStorage.GetName(_currentLocale,(uint)jobId))}");
-                    else
-                    {
-                        ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f);
-                        ImGui.TextUnformatted($"{Utils.Capitalize(_globalCache.JobStorage.GetName(_currentLocale,(uint)jobId))}");
-                        ImGui.PopStyleVar();
-                    }
-                    ImGui.TableNextRow();
-                    ImGui.TableSetColumnIndex(1);
-                    bool maxLevel = (jobId == ClassJob.BLU) ? job.Level == 80 : job.Level == 100;
-                    Utils.DrawLevelProgressBar(job.Exp, _globalCache.JobStorage.GetNextLevelExp(job.Level), tooltip, active, maxLevel);
+                    ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f);
+                    ImGui.TextUnformatted($"{job.Level}");
+                    ImGui.PopStyleVar();
                 }
+                ImGui.TableSetColumnIndex(1);
+                if (active)
+                        ImGui.TextUnformatted($"{Utils.Capitalize(_globalCache.JobStorage.GetName(_currentLocale,(uint)jobId))}");
+                else
+                {
+                    ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f);
+                        ImGui.TextUnformatted($"{Utils.Capitalize(_globalCache.JobStorage.GetName(_currentLocale,(uint)jobId))}");
+                    ImGui.PopStyleVar();
+                }
+                ImGui.TableNextRow();
+                ImGui.TableSetColumnIndex(1);
+                bool maxLevel = (jobId == ClassJob.BLU) ? job.Level == 80 : job.Level == 100;
+                Utils.DrawLevelProgressBar(job.Exp, _globalCache.JobStorage.GetNextLevelExp(job.Level), tooltip, active, maxLevel);
+            }
             if (ImGui.IsItemHovered())
             {
                 ImGui.BeginTooltip();

--- a/Altoholic/Windows/MainWindow.cs
+++ b/Altoholic/Windows/MainWindow.cs
@@ -41,7 +41,7 @@ namespace Altoholic.Windows
             PvPWindow pvPWindow,
             ConfigWindow configWindow
         )
-            : base(name, ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse)
+            : base(name,/* ImGuiWindowFlags.NoResize |*/ ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse) // I'm commendint out the NoResize flag because it is causing issues with the window size when scaling above 100%; if you scale up to 300%, the window resizes to be much larger and you can't resize back down
         {
             SizeConstraints = new WindowSizeConstraints
             {
@@ -121,7 +121,7 @@ namespace Altoholic.Windows
                     CharactersWindow.Draw();
                 }
             }
-        
+
             using (var detailsTab = ImRaii.TabItem($"{_globalCache.AddonStorage.LoadAddonString(_currentLocale, 6361)}"))
             {
                 if (detailsTab.Success)
@@ -138,7 +138,7 @@ namespace Altoholic.Windows
                     JobsWindow.Draw();
                 }
             }
-        
+
             using (var currenciesTab = ImRaii.TabItem($"{_globalCache.AddonStorage.LoadAddonString(_currentLocale, 761)}"))
             {
                 if (currenciesTab.Success)
@@ -146,7 +146,7 @@ namespace Altoholic.Windows
                     CurrenciesWindow.Draw();
                 }
             }
-        
+
             using (var inventoryTab = ImRaii.TabItem($"{_globalCache.AddonStorage.LoadAddonString(_currentLocale, 520)}"))// Inventory
             {
                 if (inventoryTab.Success)
@@ -154,7 +154,7 @@ namespace Altoholic.Windows
                     InventoriesWindow.Draw();
                 }
             }
-        
+
             using (var retainersTab = ImRaii.TabItem($"{_globalCache.AddonStorage.LoadAddonString(_currentLocale, 532)}"))
             {
                 if (retainersTab.Success)

--- a/Altoholic/Windows/ProgressWindow.cs
+++ b/Altoholic/Windows/ProgressWindow.cs
@@ -271,11 +271,11 @@ namespace Altoholic.Windows
                 ImGui.TableSetupColumn($"###CharactersProgress#All#Event#CosmicExplorationRewards#Name",
                     ImGuiTableColumnFlags.WidthFixed, 260);
                 ImGui.TableSetupColumn($"###CharactersProgress#All#Event#CosmicExplorationRewards#Currency",
-                    ImGuiTableColumnFlags.WidthFixed, 25);
+                    ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(25));
                 foreach (Character c in chars)
                 {
                     ImGui.TableSetupColumn($"###CharactersProgress#All#Event#CosmicExplorationRewards#{c.CharacterId}",
-                        ImGuiTableColumnFlags.WidthFixed, 20);
+                        ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                 }
 
                 ImGui.TableNextRow();
@@ -321,11 +321,11 @@ namespace Altoholic.Windows
                 ImGui.TableSetupColumn($"###CharactersProgress#All#Event#CosmicExplorationRewards#Name",
                     ImGuiTableColumnFlags.WidthFixed, 260);
                 ImGui.TableSetupColumn($"###CharactersProgress#All#Event#CosmicExplorationRewards#Currency",
-                    ImGuiTableColumnFlags.WidthFixed, 25);
+                    ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(25));
                 foreach (Character c in chars)
                 {
                     ImGui.TableSetupColumn($"###CharactersProgress#All#Event#CosmicExplorationRewards#{c.CharacterId}",
-                        ImGuiTableColumnFlags.WidthFixed, 20);
+                        ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                 }
 
                 ImGui.TableNextRow();
@@ -524,7 +524,7 @@ namespace Altoholic.Windows
                     {
                         ImGui.TableSetupColumn(
                             $"###CharactersProgress#All#Duty#{duName}_{ex.i}#Table#{c.CharacterId}",
-                            ImGuiTableColumnFlags.WidthFixed, 20);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                     }
 
                     ImGui.TableNextRow();
@@ -582,7 +582,7 @@ namespace Altoholic.Windows
                 {
                     ImGui.TableSetupColumn(
                         $"###CharactersProgress#All#Duty#{duName}_{ex.i}#Table#{c.CharacterId}",
-                        ImGuiTableColumnFlags.WidthFixed, 20);
+                        ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                 }
 
                 ImGui.TableNextRow();
@@ -649,7 +649,8 @@ namespace Altoholic.Windows
                 //ImGui.TextUnformatted(completed ? "\u2713" : unlocked ? "\u25ef" : "");
                 // Todo: Use line below on weird non default font
                 ImGui.PushFont(UiBuilder.IconFont);
-                ImGui.TextUnformatted(completed ? FontAwesomeIcon.Check.ToIconString() : unlocked ? FontAwesomeIcon.Circle.ToIconString() : "");
+
+                Utils.CentreText(completed ? FontAwesomeIcon.Check.ToIconString() : unlocked ? FontAwesomeIcon.Circle.ToIconString() : "");
                 ImGui.PopFont();
                 if (ImGui.IsItemHovered())
                 {
@@ -679,7 +680,7 @@ namespace Altoholic.Windows
             foreach (Character c in chars)
             {
                 ImGui.TableSetupColumn($"###CharactersProgress#All#MSQ#{c.CharacterId}",
-                    ImGuiTableColumnFlags.WidthFixed, 20);
+                    ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
             }
 
             ImGui.TableNextRow();
@@ -870,7 +871,7 @@ namespace Altoholic.Windows
                     foreach (Character c in chars)
                     {
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#2025#{c.CharacterId}",
-                            ImGuiTableColumnFlags.WidthFixed, 20);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                     }
 
                     ImGui.TableNextRow();
@@ -930,7 +931,7 @@ namespace Altoholic.Windows
                     foreach (Character c in chars)
                     {
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#2024#{c.CharacterId}",
-                            ImGuiTableColumnFlags.WidthFixed, 20);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                     }
 
                     ImGui.TableNextRow();
@@ -1009,7 +1010,7 @@ namespace Altoholic.Windows
                     foreach (Character c in chars)
                     {
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#2023#{c.CharacterId}",
-                            ImGuiTableColumnFlags.WidthFixed, 20);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                     }
 
                     ImGui.TableNextRow();
@@ -1078,7 +1079,7 @@ namespace Altoholic.Windows
                     foreach (Character c in chars)
                     {
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#2022#{c.CharacterId}",
-                            ImGuiTableColumnFlags.WidthFixed, 20);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                     }
 
                     ImGui.TableNextRow();
@@ -1150,7 +1151,7 @@ namespace Altoholic.Windows
                     foreach (Character c in chars)
                     {
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#2021#{c.CharacterId}",
-                            ImGuiTableColumnFlags.WidthFixed, 20);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                     }
 
                     ImGui.TableNextRow();
@@ -1216,7 +1217,7 @@ namespace Altoholic.Windows
                     foreach (Character c in chars)
                     {
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#2020#{c.CharacterId}",
-                            ImGuiTableColumnFlags.WidthFixed, 20);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                     }
 
                     ImGui.TableNextRow();
@@ -1286,7 +1287,7 @@ namespace Altoholic.Windows
                     foreach (Character c in chars)
                     {
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#2019#{c.CharacterId}",
-                            ImGuiTableColumnFlags.WidthFixed, 20);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                     }
 
                     ImGui.TableNextRow();
@@ -1355,7 +1356,7 @@ namespace Altoholic.Windows
                     foreach (Character c in chars)
                     {
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#2018#{c.CharacterId}",
-                            ImGuiTableColumnFlags.WidthFixed, 20);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                     }
 
                     ImGui.TableNextRow();
@@ -1425,7 +1426,7 @@ namespace Altoholic.Windows
                     foreach (Character c in chars)
                     {
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#2017#{c.CharacterId}",
-                            ImGuiTableColumnFlags.WidthFixed, 20);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                     }
 
                     ImGui.TableNextRow();
@@ -1498,7 +1499,7 @@ namespace Altoholic.Windows
                     foreach (Character c in chars)
                     {
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#2013141516#{c.CharacterId}",
-                            ImGuiTableColumnFlags.WidthFixed, 20);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                     }
 
                     ImGui.TableNextRow();
@@ -1634,11 +1635,11 @@ namespace Altoholic.Windows
                     ImGui.TableSetupColumn($"###CharactersProgress#All#Event#blundervilleRewards#Name",
                         ImGuiTableColumnFlags.WidthFixed, 260);
                     ImGui.TableSetupColumn($"###CharactersProgress#All#Event#blundervilleRewards#Currency",
-                        ImGuiTableColumnFlags.WidthFixed, 25);
+                        ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(25));
                     foreach (Character c in chars)
                     {
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#blundervilleRewards#{c.CharacterId}",
-                            ImGuiTableColumnFlags.WidthFixed, 20);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                     }
 
                     ImGui.TableNextRow();
@@ -1712,11 +1713,11 @@ namespace Altoholic.Windows
                 ImGui.TableSetupColumn($"###CharactersProgress#All#Event#MogRewards#Event2025_1#Name",
                     ImGuiTableColumnFlags.WidthFixed, 270);
                 ImGui.TableSetupColumn($"###CharactersProgress#All#Event#MogRewards#Event2025_1#Currency",
-                    ImGuiTableColumnFlags.WidthFixed, 20);
+                    ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                 foreach (Character c in chars)
                 {
                     ImGui.TableSetupColumn($"###CharactersProgress#All#Event#MogRewards#Event2025_1#{c.CharacterId}",
-                        ImGuiTableColumnFlags.WidthFixed, 20);
+                        ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                 }
 
                 ImGui.TableNextRow();
@@ -1941,11 +1942,11 @@ namespace Altoholic.Windows
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#MogRewards#Event2024_3#Name",
                             ImGuiTableColumnFlags.WidthFixed, 270);
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#MogRewards#Event2024_3#Currency",
-                            ImGuiTableColumnFlags.WidthFixed, 20);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         foreach (Character c in chars)
                         {
                             ImGui.TableSetupColumn($"###CharactersProgress#All#Event#MogRewards#Event2024_3#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2009,12 +2010,12 @@ namespace Altoholic.Windows
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#MogRewards#Event2024_2#Name",
                             ImGuiTableColumnFlags.WidthFixed, 270);
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#MogRewards#Event2024_2#Currency",
-                            ImGuiTableColumnFlags.WidthFixed, 25);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(25));
                         foreach (Character c in chars)
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2024_2#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2077,12 +2078,12 @@ namespace Altoholic.Windows
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#MogRewards#Event2024_1#Name",
                             ImGuiTableColumnFlags.WidthFixed, 270);
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#MogRewards#Event2024_1#Currency",
-                            ImGuiTableColumnFlags.WidthFixed, 25);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(25));
                         foreach (Character c in chars)
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2024_1#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2145,12 +2146,12 @@ namespace Altoholic.Windows
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#MogRewards#Event2023_2#Name",
                             ImGuiTableColumnFlags.WidthFixed, 270);
                         ImGui.TableSetupColumn($"###CharactersProgress#All#Event#MogRewards#Event2023_2#Currency",
-                            ImGuiTableColumnFlags.WidthFixed, 25);
+                            ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(25));
                         foreach (Character c in chars)
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2023_2#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2241,7 +2242,7 @@ namespace Altoholic.Windows
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2023_1#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2313,7 +2314,7 @@ namespace Altoholic.Windows
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2022_3#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2384,7 +2385,7 @@ namespace Altoholic.Windows
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2022_2#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2452,7 +2453,7 @@ namespace Altoholic.Windows
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2022_1#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2517,7 +2518,7 @@ namespace Altoholic.Windows
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2021_3#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2585,7 +2586,7 @@ namespace Altoholic.Windows
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2021_2#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2652,7 +2653,7 @@ namespace Altoholic.Windows
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2021_1#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2721,7 +2722,7 @@ namespace Altoholic.Windows
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2020_2#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2789,7 +2790,7 @@ namespace Altoholic.Windows
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2020_1#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2859,7 +2860,7 @@ namespace Altoholic.Windows
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2019_2#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -2929,7 +2930,7 @@ namespace Altoholic.Windows
                         {
                             ImGui.TableSetupColumn(
                                 $"###CharactersProgress#All#Event#MogRewards#Event2019_1#{c.CharacterId}",
-                                ImGuiTableColumnFlags.WidthFixed, 20);
+                                ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
                         }
 
                         ImGui.TableNextRow();
@@ -3488,7 +3489,7 @@ namespace Altoholic.Windows
             foreach (Character c in chars)
             {
                 ImGui.TableSetupColumn($"###CharactersProgress#All#Hildibrand#{c.CharacterId}",
-                    ImGuiTableColumnFlags.WidthFixed, 20);
+                    ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
             }
 
             ImGui.TableNextRow();
@@ -3564,7 +3565,7 @@ namespace Altoholic.Windows
             foreach (Character c in chars)
             {
                 ImGui.TableSetupColumn($"###CharactersProgress#All#RoleQuest#{c.CharacterId}",
-                    ImGuiTableColumnFlags.WidthFixed, 20);
+                    ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
             }
 
             ImGui.TableNextRow();
@@ -3667,7 +3668,7 @@ namespace Altoholic.Windows
             foreach (Character c in chars)
             {
                 ImGui.TableSetupColumn($"###CharactersProgress#All#Tribe#{c.CharacterId}",
-                    ImGuiTableColumnFlags.WidthFixed, 20);
+                    ImGuiTableColumnFlags.WidthFixed, Utils.GetColumnWidthScaled(20));
             }
 
             ImGui.TableNextRow();


### PR DESCRIPTION
* Adding a couple helper functions to Utils that are used in just a couple places, like the JobsWindow to help with column width and making it easier to read stuff. There has to be a better way to do it, but this is an interim solution for now.
* Commenting out the window NoResize flag due to scaling. You have a minimum size anyway, so not really seeing the point to this.

Note: I haven't checked every single Window for text clipping, the ones most notable are the ones I've changed.
![messy](https://github.com/user-attachments/assets/bf00a38b-ff4a-488c-b98a-1f0efee48294)
![slightlybetter](https://github.com/user-attachments/assets/e08a810d-4363-431c-ae4b-a96efb85b135)

![clipped](https://github.com/user-attachments/assets/c1d99b0f-f652-4bcf-9c1c-c4ea32309875)
![notextclipping](https://github.com/user-attachments/assets/a36bae0d-5512-44c0-a30d-878500558a99)
